### PR TITLE
Fixed a bug where Chrome forcefully adds a duplicate image, which wou…

### DIFF
--- a/dist/all.js
+++ b/dist/all.js
@@ -2591,6 +2591,16 @@ e=a[0],c=a[2]):(d=a[2],e=a[0],c=a[1]);if(0>function(a,b,c){var d=b.x;b=b.y;retur
 
                     item.appendChild(img);
                     list.appendChild(item);
+
+                    /**
+                     *  Upon loading the DOM, delete the duplicate image that
+                     *  Chrome likes to force into the page.
+                     */
+                    if (navigator.userAgent.indexOf("Chrome") != -1) {
+                        let duplicateImage = document.body.getElementsByTagName('img')[0];
+                        duplicateImage.remove();
+                    }
+
                     items.push(item);
                 }
             });


### PR DESCRIPTION
…ld ruin the background. The image is now being deleted if the user is on Chrome on every initList. This bug wouldn't occur on Opera. The browser check can be easily spoofed, though: https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser

Please note that you may find a different place suitable for this kind of a check.