### PR TITLE
Add modifier key to enable default drag behaviour [49]

### DIFF
--- a/dist/all.js
+++ b/dist/all.js
@@ -2881,6 +2881,8 @@ e=a[0],c=a[2]):(d=a[2],e=a[0],c=a[1]);if(0>function(a,b,c){var d=b.x;b=b.y;retur
             }
         },
         dragstart: function dragstart(event) {
+            if (event.altKey) return;
+            
             if (event.target.localName === 'img') {
                 event.preventDefault();
             }
@@ -2898,6 +2900,7 @@ e=a[0],c=a[2]):(d=a[2],e=a[0],c=a[1]);if(0>function(a,b,c){var d=b.x;b=b.y;retur
                 return;
             } // Prevent default behaviours as page zooming in touch devices.
 
+            if (event.altKey) return;
 
             event.preventDefault();
 

--- a/js/lib/viewer.min.js
+++ b/js/lib/viewer.min.js
@@ -1651,6 +1651,8 @@
             }
         },
         dragstart: function dragstart(event) {
+            if (event.altKey) return;
+            
             if (event.target.localName === 'img') {
                 event.preventDefault();
             }
@@ -1668,6 +1670,7 @@
                 return;
             } // Prevent default behaviours as page zooming in touch devices.
 
+            if (event.altKey) return;
 
             event.preventDefault();
 


### PR DESCRIPTION
Addresses [this issue](https://github.com/Ademking/BetterViewer/issues/49) to re-enable default drag behaviour, which absolutely still has its uses.
Shift and Ctrl had issues; though they did allow the default drag behaviour to occur, they disabled the drop behaviour that comes with it. Alt lacked that issue, allowing both vanilla drag and vanilla drop to function.

I wasn't sure which file needed to be edited, so I just edited both. 
Please correct me if I did anything wrong.